### PR TITLE
Use non-parallel algorithm and fix engine strength

### DIFF
--- a/src/scene/game_scene.rs
+++ b/src/scene/game_scene.rs
@@ -110,9 +110,9 @@ fn to_square(x: usize, y: usize) -> SQ {
 #[derive(Clone, Copy, PartialEq)]
 pub enum GameMode {
     PvP = 0,
-    EasyBot = 1,
-    NormalBot = 2,
-    HardBot = 4,
+    EasyBot = 2,
+    NormalBot = 4,
+    HardBot = 6,
     // Could go up to about 8-10 (depending on the algo) before getting too slow. But probably fairly unbeatable then.
 }
 
@@ -388,7 +388,7 @@ impl GameScene {
     fn do_bot_move(board: Board, depth: u16) -> BitMove {
         println!("Bot is working...");
         //let depth = board.depth() + 1; // Should probably be this
-        let bot_bit_move = JamboreeSearcher::best_move(board, depth);
+        let bot_bit_move = AlphaBetaSearcher::best_move(board, depth);
         bot_bit_move
     }
 


### PR DESCRIPTION
Since the reMarkable (1, not sure about version 2) only has a single core processor, it makes no sense to use the parallel Jamboree search algorithm.
Using the AlphaBeta algorithm instead provides much faster results for the same play strokes.

Notes: 
- Measured with search depth 6, on similar opening moved for white (1. D4, 2. Bf4, 3.Nf3)
  - Jamboree plays 1. ... c6 in 26s, 2. ... Qb6 in 145s, 3. ... Qxb2 in >180s
  - AlphaBeta plays the same moves in 11s, 38s and 30s respectively
  - IterativeSearch plays 1. ... c6 in 7s only!, followed by 2. ... c5? in 18s, blundering a pawn. Faster but plays worse for the same depth.
- Using depth 2 for easy, because depth 1 is too simple even for beginners; depth 4 as intermediate because this is the best level where the bot plays "instantly", so good for training blitz games, and depth 6 for hard because depth 7 may take discouragingly long to make even the opening moves. (1. ... e6 in 74s, 2. ... d6 in 690s)

It may make sense at some point to split the engine from the front-end to allow using an online engine for better opponent strengths without risking ruining the battery by having the CPU running 100% for hours at a time in a game. If the engine library allows setting a maximum duration before sending a move, it may make sense to use it as a preparation for further time control settings for rapid or blitz games.